### PR TITLE
Fix reading config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@meemeelab/node-anime-viewer-test",
+  "name": "node-anime-viewer",
   "version": "1.0.1",
   "description": "View anime from nodejs",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-anime-viewer",
+  "name": "@meemeelab/node-anime-viewer-test",
   "version": "1.0.1",
   "description": "View anime from nodejs",
   "main": "src/index.js",

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,7 @@
 import {readFileSync} from "fs";
 import {resolve} from "path";
 
-let __dirname = new URL('', import.meta.url).pathname;
-if (process.platform === 'win32') {
-  __dirname = __dirname.slice(1); // On Windows, the path starts with a unneeded slash
-}
+const __dirname = new URL('', import.meta.url).pathname;
 const config = JSON.parse(readFileSync(
   resolve(__dirname, "../../package.json"),
 ));

--- a/src/config.js
+++ b/src/config.js
@@ -8,3 +8,5 @@ if (process.platform === 'win32') {
 const config = JSON.parse(readFileSync(
   resolve(__dirname, "../../package.json"),
 ));
+
+export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+import {readFileSync} from "fs";
+import {resolve} from "path";
+
+const __dirname = new URL('', import.meta.url).pathname;
+const config = JSON.parse(readFileSync(
+  resolve(__dirname, "../../package.json"),
+));
+
+export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,10 @@
 import {readFileSync} from "fs";
 import {resolve} from "path";
 
-const __dirname = new URL('', import.meta.url).pathname;
+let __dirname = new URL('', import.meta.url).pathname;
+if (process.platform === 'win32') {
+  __dirname = __dirname.slice(1); // On Windows, the path starts with a unneeded slash
+}
 const config = JSON.parse(readFileSync(
   resolve(__dirname, "../../package.json"),
 ));

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,10 @@
 import {readFileSync} from "fs";
 import {resolve} from "path";
 
-const __dirname = new URL('', import.meta.url).pathname;
+let __dirname = new URL('', import.meta.url).pathname;
+if (process.platform === 'win32') {
+  __dirname = __dirname.slice(1); // On Windows, the path starts with a unneeded slash
+}
 const config = JSON.parse(readFileSync(
   resolve(__dirname, "../../package.json"),
 ));
-
-export default config;

--- a/src/modules/interface.js
+++ b/src/modules/interface.js
@@ -1,7 +1,6 @@
 import Terminal from "terminal-kit";
-import {readFileSync} from "fs";
 
-const config = JSON.parse(readFileSync("package.json"));
+import config from '../config.js';
 
 export default class Interface {
     term;


### PR DESCRIPTION
Reading a file using a relative path will always try searching for the file in the current working directory (from where it is called from, not where the application is in). This means that installing this application globally would not work.

This pull request fixes that problem.