### PR TITLE
Fix in case history file path's parent does not exist

### DIFF
--- a/src/modules/history.js
+++ b/src/modules/history.js
@@ -12,9 +12,9 @@ export class HistoryManager {
 
     constructor() {
         if (!fs.existsSync(historyFileDir)) {
-            fs.mkdirSync(historyFileDir);
+            fs.mkdirSync(historyFileDir, { recursive: true });
         }
-        
+
         if (fs.existsSync(historyFilePath)) {
             this._history = JSON.parse(fs.readFileSync(historyFilePath));
         } else {


### PR DESCRIPTION
This can happen on android, where ~/.local may not exist.

```
node:fs:1336
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, mkdir '/data/data/com.termux/files/home/.local/share/node-anime-viewer'
    at Object.mkdirSync (node:fs:1336:3)
    at new HistoryManager (file:///data/data/com.termux/files/usr/lib/node_modules/node-anime-viewer/src/modules/history.js:15:16)
    at file:///data/data/com.termux/files/usr/lib/node_modules/node-anime-viewer/src/modules/history.js:76:16
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12) {
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: '/data/data/com.termux/files/home/.local/share/node-anime-viewer'
}
```