### PR TITLE
Fix invalid episode number concatenating instead of adding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ function showVLCExitInterface(interfaces, options) {
     const vlcExitInterface = new VLCExitInterface(Terminal.terminal, {
         playNextEpisode: () => {
             if (options.selectedEpisode.episode >= options.availableEpisodes.length) {
-                Terminal.terminal.white('\n\n').red('Episode ' + options.selectedEpisode.episode + 1 + ' is not available.\n');
+                Terminal.terminal.white('\n\n').red('Episode ' + (parseInt(options.selectedEpisode.episode) + 1)  + ' is not available.\n');
                 Terminal.terminal.white('Press any key to continue...');
                 Terminal.terminal.once('key', () => {
                     interfaces.selectEpisodeInterface.reInitialize();
@@ -251,7 +251,7 @@ function showVLCExitInterface(interfaces, options) {
         },
         playPreviousEpisode: () => {
             if (options.selectedEpisode.episode <= 1) {
-                Terminal.terminal.white('\n\n').red('Episode ' + options.selectedEpisode.episode - 1 + ' is not available.\n');
+                Terminal.terminal.white('\n\n').red('Episode ' + (parseInt(options.selectedEpisode.episode) - 1) + ' is not available.\n');
                 Terminal.terminal.white('Press any key to continue...');
                 Terminal.terminal.once('key', () => {
                     interfaces.selectEpisodeInterface.reInitialize();


### PR DESCRIPTION
Fixes this issue:
Anime is 12 episodes, when next episode is pressed after playing episode 12, the output would be "Episode 121 is not available." Instead of "Episode 13 is not available."

And when previous episode is picked on episode one, it now displays "Episode 0 is not available." instead of "Nan is not available."